### PR TITLE
Use 'gridImage' instead of 'image' from Tarkov Tools GraphQL API

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -49,6 +49,7 @@
     "definitions": {
       "name": "api-definitions",
       "version": "1.0.0",
+      "extraneous": true,
       "license": "ISC"
     },
     "node_modules/@angular-devkit/core": {
@@ -2469,10 +2470,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/api-definitions": {
-      "resolved": "definitions",
-      "link": true
     },
     "node_modules/append-field": {
       "version": "1.0.0",
@@ -10802,9 +10799,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "api-definitions": {
-      "version": "file:definitions"
     },
     "append-field": {
       "version": "1.0.0",

--- a/apps/api/src/graphql/queries.ts
+++ b/apps/api/src/graphql/queries.ts
@@ -6,7 +6,7 @@ export const getItemsByName = gql`
       id
       name
       wikiLink
-      imageLink
+      gridImageLink
       avg24hPrice
       traderPrices {
         price

--- a/apps/api/src/items/items.service.ts
+++ b/apps/api/src/items/items.service.ts
@@ -64,7 +64,7 @@ export class ItemsService implements OnModuleInit {
         itemId: item.id,
         itemName: item.name,
         wikiLink: item.wikiLink,
-        imageLink: item.imageLink,
+        imageLink: item.gridImageLink,
         quests: this.getQuestsRelatedToItem(item.id),
         barters: [],
         hideoutCrafts: [],


### PR DESCRIPTION
- [x] The branch was rebased on the target branch,
- [x] Linked to GitHub Issue, closes #18 
- [x] PR has been assigned,
- [x] A review has been requested if needed.

---

## 🎯 This PR...
replaces the `imageLink` attribute of an `ItemSearchResult` to the `gridImageLink` provided by Tarkov Tools' GraphQL.

## 🔍 Context
**Grid images** provided are better icons than the classic ones provided by TT GQL.

### Image
![image](https://user-images.githubusercontent.com/56871713/149217638-715519b1-5b0c-46af-afbb-8d9290cbfcd2.png)

### Grid image
![image](https://user-images.githubusercontent.com/56871713/149217703-7b6a9604-bca6-4946-97f7-4a1572cc59f9.png)


## 🧪 Testing
Make an API `GET` request on `localhost:3000/api/items/salewa` and check the provided image.