### PR TITLE
Fix empty trader prices crashing server

### DIFF
--- a/apps/api/src/items/items.service.ts
+++ b/apps/api/src/items/items.service.ts
@@ -61,7 +61,7 @@ export class ItemsService implements OnModuleInit {
   }
 
   formatFleaMarketPrice(price): string {
-    return price ? `${price} @ FleaMarket` : 'Cannot sell this item';
+    return price > 0 ? `${price} @ FleaMarket` : 'Cannot sell this item';
   }
 
   async search(query: string): Promise<ItemSearchResult[]> {


### PR DESCRIPTION
- [x] The branch was rebased on the target branch,
- [x] Linked to GitHub Issue, closes #13 
- [x] PR has been assigned,
- [x] A review has been requested if needed.

---

## 🎯 This PR...
fixes an edge case: searching for an item that cannot be sold to traders previously crashed the API.

## 🔍 Context
Searching for secure containers for example, that cannot be sold to traders, tried to reduce the traderPrices, which were empty.
Apparently, JS can't just "skip" the reduce if the provided array is empty, and therefore crashed.

## 🧪 Testing
`GET` request on `localhost:3000/api/items/secure` should not return an error 500 anymore.
