### PR TITLE
Add price checks for market and trader prices of unsellable items

### DIFF
--- a/apps/api/src/items/items.spec.ts
+++ b/apps/api/src/items/items.spec.ts
@@ -41,5 +41,19 @@ describe('ItemsController', () => {
       expect(data[0].quests).toBeDefined();
       expect(data[0].quests.length).toEqual(1);
     });
+
+    describe('with empty trader prices (cannot be sold)', () => {
+      it('returns a sell price of 0', async () => {
+        const data = await controller.searchItems('secure');
+        expect(data).toBeInstanceOf(Array);
+
+        const secureContainers = data.filter(item =>
+          item.itemName.includes('Alpha'),
+        );
+
+        expect(secureContainers[0].marketPrice).toBe('Cannot sell this item');
+        expect(secureContainers[0].traderPrice).toBe('Cannot sell this item');
+      });
+    });
   });
 });


### PR DESCRIPTION
- [x] The branch was rebased on the target branch,
- [x] Linked to GitHub Issue, closes #22 
- [x] PR has been assigned,
- [x] A review has been requested if needed.

---

## 🎯 This PR...
Adds two tests that make sure that unsellable items don't crash the API.

## 🔍 Context
Previously, we've had to fix searching for an unsellable item, as it contained an empty traderPrices array which crashed the server. The fix PR already got merged as it was a hotfix, but didn't implement tests that make sure it doesn't happen again. This PR aims to do so.
